### PR TITLE
Include the inc_none checkboxes in the search query

### DIFF
--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -32,6 +32,14 @@ const SearchForm = ({ setSearch, setSearchQuery, setShowSearchResults }) => {
       }
     }
 
+    // incNoneValues are the checkboxes to determine whether the search results include listings with incomplete data
+    const incNoneValues = ["inc_none_beds", "inc_none_rooms", "inc_none_size", "inc_none_plot"];
+    incNoneValues.forEach(value => {
+      if (submitData[value] === false) {
+        searchQuery[value] = submitData[value];
+      }
+    })
+
     setSearchQuery(searchQuery);
     setShowSearchResults(true);
   }

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -31,11 +31,21 @@ export const getSearchURL = searchQuery => {
     }
   });
   
+  // exclude listings with incomplete data if the user has unchecked the box
+  if (searchQuery.inc_none_beds === false) {
+    query += "&inc_none_beds=false";
+  }
+  if (searchQuery.inc_none_rooms === false) {
+    query += "&inc_none_rooms=false";
+  }
+  if (searchQuery.inc_none_size === false) {
+    query += "&inc_none_size=false";
+  }
+  if (searchQuery.inc_none_plot === false) {
+    query += "&inc_none_plot=false";
+  }
+  
   // &search_radius=0
-  // &inc_none_beds=true
-  // &inc_none_size=true
-  // &inc_none_plot=true
-  // inc_none_rooms
   
   if (query) query = "?" + query.slice(1);
   


### PR DESCRIPTION
- Include the 4 `inc_none_*` checkboxes in the search
- Use `=== false` as the backend server is set up to expect these to be `true` by default, so these should only be sent in the query string if they are explicitly `false`