### PR TITLE
Update animation positioning, add fade out

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,6 @@ function App() {
 
   useEffect(() => {
     if (typeof queryURL === "string") {
-      // console.log(baseURL + queryURL)
       fetch(baseURL + queryURL)
         .then(res => res.json())
         .then(data => {

--- a/src/components/ListingsContainer.js
+++ b/src/components/ListingsContainer.js
@@ -48,7 +48,7 @@ const ListingsContainer = ({ listings, loadingListings, loadingTimer, noListings
         } else if (noListingsRef.current) {
           handleScroll(noListingsRef);
         }
-      }, 3600 - timeElapsed);
+      }, 4100 - timeElapsed);
     }
   }, [listings]);
 

--- a/src/scss/_animations.scss
+++ b/src/scss/_animations.scss
@@ -1,23 +1,22 @@
-
 @keyframes grow-house {
   0% {
-    transform: translateX(-50%) scale(0);
+    transform: translate(-50%, -2.65rem) scale(0);
     opacity: 0;
   }
   60% {
-    transform: translateX(-50%) scale(1);
+    transform: translate(-50%, -2.65rem) scale(1);
     opacity: 0.6;
   }
   70% {
-    transform: translateX(-50%) scale(1.15);
+    transform: translate(-50%, -2.65rem) scale(1.15);
     opacity: 0.7;
   }
   80% {
-    transform: translateX(-50%) scale(1.215);
+    transform: translate(-50%, -2.65rem) scale(1.215);
     opacity: 0.8;
   }
   100% {
-    transform: translateX(-50%) scale(1);
+    transform: translate(-50%, -2.65rem) scale(1);
     opacity: 1;
   }
 }
@@ -58,22 +57,11 @@
 
 @keyframes for-sale-sign-slide-down {
   0% {
-    top: -2rem;
+    transform: translate(5.55rem, -9.5rem);
     opacity: 0;
   }
   100% {
-    top: 9.7rem;
-    opacity: 1;
-  }
-}
-
-@keyframes for-sale-sign-slide-down-mobile {
-  0% {
-    top: -2rem;
-    opacity: 0;
-  }
-  100% {
-    top: 9rem;
+    transform: translate(5.55rem, 0);
     opacity: 1;
   }
 }
@@ -1580,5 +1568,37 @@
   100% {
     opacity: 1;
     height: 2.25rem;  // this needs updating
+  }
+}
+
+@keyframes fade-out {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes disappear {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  20% {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+  30% {
+    transform: scale(1.15);
+    opacity: 1;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0);
+    opacity: 0;
   }
 }

--- a/src/scss/_loading.scss
+++ b/src/scss/_loading.scss
@@ -10,6 +10,7 @@
   top: 0;
   left: 0;
   z-index: 60;
+  animation: disappear 0.6s linear forwards 3.9s;
 }
 
 .loading-circle-container {
@@ -20,26 +21,25 @@
   overflow: hidden;
   background: linear-gradient(#b3d8e8, #569ebb);
   box-shadow: 0 0 1rem 0.2rem rgb(88, 88, 88);
-  // top: 50%;
-  // left: 50%;
-  // transform: translate(-50%, -50%);
+  animation: disappear 0.5s linear forwards 3.6s;
 }
 
 .loading-text {
   position: relative;
   color: rgb(210, 210, 210);
-  font-size: 2rem;
+  font-size: 2.1rem;
   font-weight: bold;
   text-align: center;
+  animation: fade-out 0.3s linear forwards 3.6s;
 }
 
 .grass {
   position: absolute;
-  top: 13.75rem;
   height: 1rem;
   width: 100%;
   background: linear-gradient(#99e527, #80c21e);
-  bottom: 0;
+  top: 50%;
+  transform: translateY(4.25rem);
   left: 0;
   z-index: 8;
 
@@ -212,44 +212,48 @@
   position: absolute;
   background: #8b8b8b;
   width: 100%;
-  height: 68px;
-  bottom: 0;
+  height: 4.5rem;
+  top: 50%;
+  transform: translateY(5rem);
   left: 0;
   z-index: 15;
 
   &::before {
     content: "";
     position: absolute;
-    width: 55px;
+    width: 3.4rem;
     height: 7px;
     background-color: #ffefe9;
-    top: 31px;
-    left: 45px;
+    top: 2rem;
+    left: 50%;
+    transform: translateX(-6.5rem);
   }
 
   &::after {
     content: "";
     position: absolute;
-    width: 55px;
+    width: 3.4rem;
     height: 7px;
     background-color: #ffefe9;
-    top: 31px;
-    left: 160px;
+    top: 2rem;
+    left: 50%;
+    transform: translateX(1rem);
   }
 }
 
 .house {
   position: absolute;
-  width: 165px;
-  height: 110px;
+  width: 10.3rem;
+  height: 6.9rem;
   background: #eadecf;
   // background-image: url("../../public/wall-21534_1280.jpg");
   // background-repeat: no-repeat;
   // background-size: cover;
   left: 50%;
-  bottom: 5rem;
-  transform: translateX(-50%);
+  top: 50%;
+  transform: translate(-50%, -2.65rem);
   box-shadow: #7f9bb3 -3px -3px 8px;
+  z-index: 2;
   animation: grow-house 0.75s linear forwards;
 }
 
@@ -272,7 +276,7 @@
     left: -10px;
     bottom: -3px;
     opacity: 0;
-    animation: roof 0.75s linear forwards;   
+    animation: roof 0.75s linear forwards; 
     animation-delay: 2.1s;
   }
 }
@@ -287,8 +291,7 @@
   border: 3px solid #a92929;
   border-bottom: none;
   opacity: 0;
-  animation: grow-house-features 0.6s linear forwards;
-  animation-delay: 0.55s;
+  animation: grow-house-features 0.6s linear forwards 0.55s;//, shrink-house-features 0.5s linear 3.2s forwards;
   z-index: 44;
 
   &::before {
@@ -375,8 +378,7 @@
   border: 3px solid #ffefe9;
   box-shadow: 2px 1px 4px 0 rgba(0, 0, 0, 0.05);
   opacity: 0;
-  animation: grow-house-features 0.5s linear forwards;
-  animation-delay: 1.25s;
+  animation: grow-house-features 0.6s linear forwards 1.25s;//, shrink-house-features 0.4s linear 3.5s forwards;
 
   &::before {
     content: "";
@@ -399,7 +401,7 @@
   }
 
   &:nth-of-type(1) {
-    animation-delay: 1s;
+    animation: grow-house-features 0.6s linear forwards 1s;//, shrink-house-features 0.4s linear 3.5s forwards;
   }
 }
 
@@ -412,9 +414,8 @@
   opacity: 0;
   top: -6rem;
   left: 2rem;
-  animation: chimney-slide-down 0.35s linear forwards;
-  animation-delay: 1.55s;
-  
+  animation: chimney-slide-down 0.35s linear forwards 1.55s;//, shrink-house-features 0.4s linear 3.5s forwards;
+ 
   &::before {
     content: "";
     position: absolute;
@@ -430,14 +431,15 @@
 
 .bush {
   position: absolute;
-  bottom: 4.7rem;
-  left: 1.85rem;
   width: 1.5rem;
   height: 1.5rem;
   background-color: #24c02a;
   border: 1px solid #24c02a;
   border-radius: 50%;
-  z-index: 5;
+  top: 50%;
+  left: 50%;
+  transform: translate(-7.5rem, 3rem);
+  // bottom: 4.7rem;
 
   &::before {
     content: "";
@@ -448,7 +450,7 @@
     box-shadow: 
     21px -3px 0 0 #24c02a,
     14px -7px 0 0 #24c02a,
-    -10px -5px 0 0 #24c02a;
+    -10px -4px 0 0 #24c02a;
   }
 
   &::after {
@@ -464,8 +466,8 @@
   }
 
   &:nth-of-type(2) {
-    left: 0.6rem;
     background-color: #24c02a;
+    transform: translate(-8.75rem, 3rem);
   }
 
   &:nth-of-type(2)::before {
@@ -490,11 +492,12 @@
   width: 0.25rem;
   background-color: #ffefe9;
   border-radius: 0.9rem 0.9rem 0 0;
-  top: 9.68rem;
-  left: 15rem;
+  top: 50%;
+  left: 50%;
+  transform: translate(5.55rem, 0);
   opacity: 0;
-  animation: for-sale-sign-slide-down 0.3s linear forwards;
-  animation-delay: 2.75s;
+  animation: for-sale-sign-slide-down 0.3s linear forwards 2.75s;
+  z-index: 2;
   
   &::before {
     position: absolute;

--- a/src/scss/_media.scss
+++ b/src/scss/_media.scss
@@ -267,25 +267,13 @@
     padding: 0;
   }
 
-  .loading-text {
-    bottom: -4.5rem;
-  }
-
   .loading-circle-container {
     position: relative;
     width: 18rem;
     height: 18rem;
   }
 
-  .grass {
-    top: 13rem;
-  }
-
   .for-sale-sign {
-    left: 14.5rem;
-    animation: for-sale-sign-slide-down-mobile 0.3s linear forwards;
-    animation-delay: 2.75s;
-
     &::before {
       width: 2.3rem;
       font-size: 0.75rem;


### PR DESCRIPTION
- Add fade out animation where the loading screen shrinks and fades out after playing the house-building animation
- Update the animation elements to position themselves relative to the center of the circle (using `top: 50%` and `left: 50%` alongside `transform: translate`), as none of the elements inside the circle shouldn't change position with the fade out animation