### PR TITLE
Add reusable scroll function and button to scroll top

### DIFF
--- a/src/components/ListingsContainer.js
+++ b/src/components/ListingsContainer.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import ReactPaginate from 'react-paginate';
 
+import { scrollTo } from '../utilities';
+
 import Listing from './Listing';
 import SortingDropdown from './SortingDropdown';
 
@@ -26,13 +28,6 @@ const ListingsContainer = ({ listings, loadingListings, loadingTimer, noListings
     });
   };
 
-  const handleScroll = ref => {
-    window.scrollTo({
-      top: ref.current.offsetTop - 24,
-      behavior: "smooth",
-    });
-  }
-
   useEffect(() => {
     // reset page to zero when listings change
     setCurrentOffset(0);
@@ -44,9 +39,9 @@ const ListingsContainer = ({ listings, loadingListings, loadingTimer, noListings
       setTimeout(() => {
         setLoadingListings(false);
         if (searchResultsContainerRef.current) {
-          handleScroll(searchResultsContainerRef);
+          scrollTo(searchResultsContainerRef.current.offsetTop - 24);
         } else if (noListingsRef.current) {
-          handleScroll(noListingsRef);
+          scrollTo(noListingsRef.current.offsetTop - 24);
         }
       }, 4100 - timeElapsed);
     }
@@ -54,10 +49,11 @@ const ListingsContainer = ({ listings, loadingListings, loadingTimer, noListings
 
   if (noListingsFound) {
     return (
-      <div className="listings-container" ref={noListingsRef}>
+      <div className="no-listings-container" ref={noListingsRef}>
         <div className="no-listings-found">
           No properties found matching your search criteria.
         </div>
+        <button className="btn-scroll" onClick={() => scrollTo(0)}>Back to top</button>
       </div>
     )
   }

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -7,6 +7,8 @@ import {
   propertyTypeMapping
 } from '../data';
 
+import { scrollTo } from '../utilities';
+
 import Dropdown from './Dropdown';
 import Input from './Input';
 import SearchSlider from './SearchSlider';
@@ -14,7 +16,6 @@ import SearchUnknown from './SearchUnknown';
 
 // add tooltip to explain to users they can select department OR area - also code this in to make sure one disables as the other gains a value
 // the input with class search-textarea should be changed to a textarea with an auto height based on what the user enters
-// add "Back to top" button after "No listings found" message
 
 const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, setNoListingsFound, setSearch, setSearchQuery }) => {
   const { register, handleSubmit, setValue, formState: { errors } } = useForm();
@@ -86,9 +87,7 @@ const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, 
   }, [searchFormRef.current]);
 
   useEffect(() => {
-    if (!showAdvanced) {
-      window.scrollTo({top: 0, behavior: "smooth"});
-    }
+    if (!showAdvanced) scrollTo(0);
   }, [showAdvanced]);
 
   if (!locationChoices.length) return null;

--- a/src/scss/_listings.scss
+++ b/src/scss/_listings.scss
@@ -16,13 +16,6 @@
   font-size: 1rem;
 }
 
-.no-listings-found {
-  font-size: 1.4rem;
-  text-align: center;
-  padding: 1rem;
-  margin: auto;
-}
-
 .listings-container {
   display: flex;
   justify-content: space-around;
@@ -30,6 +23,42 @@
   gap: 3rem;
   min-height: 25rem;
   margin-top: 2rem;
+}
+
+.no-listings-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 30rem;
+  padding: 2.5rem;
+}
+
+.no-listings-found {
+  font-size: 1.4rem;
+  text-align: center;
+}
+
+.btn-scroll {
+  font-size: 1.25rem;
+  font-weight: 500;
+  background-color: transparent;
+  outline: none;
+  border: none;
+  transition: all ease 200ms;
+  -webkit-transition: all ease 200ms;
+
+  &:hover {
+    color: rgb(0, 114, 176);
+    transition: all ease 200ms;
+    -webkit-transition: all ease 200ms;
+  }
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }
 
 .listing-container {

--- a/src/scss/_search-form.scss
+++ b/src/scss/_search-form.scss
@@ -12,7 +12,7 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  background-color: rgba(121, 121, 121, 0.5);
+  background-color: rgba(90, 90, 100, 0.6);
   overflow: hidden;
 }
 

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -74,3 +74,5 @@ export const getSearchURL = searchQuery => {
 
   return query;
 }
+
+export const scrollTo = top => window.scrollTo({top: top, behavior: "smooth"});


### PR DESCRIPTION
- Add reusable smooth scroll function `scrollTo`
- Add "back to top" button if no listings are found to scroll back to the top of the page
- Update the "no listings" CSS to incorporate the button and increase the padding