### PR TITLE
Update checkboxes to check/uncheck as input values are entered

### DIFF
--- a/src/components/CheckboxOption.js
+++ b/src/components/CheckboxOption.js
@@ -1,0 +1,30 @@
+import React, { useState, useEffect } from 'react';
+
+const CheckboxOption = ({ option, register, watch }) => {
+  const [checked, setChecked] = useState(true);
+  // if the user checks or unchecks the box, their choice overrides the default checking/unchecking when associated fields have values
+  const [userChecked, setUserChecked] = useState(false);
+  const watchFields = option.relatedFields.map(field => watch(field));
+
+  const handleUserCheck = () => {
+    setChecked(prev => !prev);
+    if (!userChecked) setUserChecked(true);
+  }
+
+  useEffect(() => {
+    if (!userChecked) {
+      if (option.relatedFields.some(field => watch(field) !== "" && watch(field) !== undefined)) {
+        setChecked(false);
+      } else setChecked(true);
+    }
+  }, [userChecked, watchFields]);
+
+  return (
+    <label className="checkbox-label" key={option.name}>
+      {option.label}
+      <input type="checkbox" {...register(option.name)} checked={checked} onClick={handleUserCheck}/>
+    </label>
+  )
+}
+
+export default CheckboxOption;

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,19 +1,18 @@
 import React, { useState } from 'react';
 
-const Input = ({ className, maxLength, name, number, placeholder, register }) => {
+const Input = ({ className, maxLength, name, number, placeholder, register, setValue }) => {
   const [inputValue, setInputValue] = useState("");
 
   // ensure only numbers can be typed in number inputs
   const handleNumberInput = e => {
     let value = e.target.value;
     if (number) {
-      [...value].forEach((char, i) => {
-        if (char.charCodeAt(0) < 48 || char.charCodeAt(0) > 57) {
-          value = value.replace(char, "");
-        }
-      });
+      value = value.replace(/[^0-9]/g, "");
     }
-    setInputValue(value);
+    // use setValue in order to link the value of the inputs to the checkboxes below - the checkboxes untick if the corresponding input has a value, but "watch" uses the value before handleNumberInput runs unless setValue is invoked
+    const newValue = number ? parseInt(value) || "" : value;
+    setValue(name, newValue);
+    setInputValue(newValue);
   }
 
   return (

--- a/src/components/Listing.js
+++ b/src/components/Listing.js
@@ -4,6 +4,8 @@ const Listing = ({ listing }) => {
   const [currentPhoto, setCurrentPhoto] = useState(0);
 
   const getListingDescription = description => {
+    if (!description) return "No description provided.";
+    
     if (typeof description === "string") {
       return description.length > 222 ? description.slice(0, 222) + "..." : description;
     }

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -19,7 +19,7 @@ import SearchUnknown from './SearchUnknown';
 // figure out why the smooth scroll isn't working on last page of listings
 
 const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, setNoListingsFound, setSearch, setSearchQuery }) => {
-  const { register, handleSubmit, setValue, formState: { errors } } = useForm();
+  const { register, handleSubmit, setValue, watch } = useForm();
   const [locationChoices, setLocationChoices] = useState([]);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [minHeight, setMinHeight] = useState(window.innerHeight + 64);
@@ -49,7 +49,7 @@ const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, 
     }
 
     // incNoneValues are the checkboxes to determine whether the search results include listings with incomplete data
-    const incNoneValues = ["inc_none_beds", "inc_none_rooms", "inc_none_size", "inc_none_plot", "inc_none_location"];
+    const incNoneValues = ["inc_none_beds", "inc_none_size", "inc_none_plot", "inc_none_location"];
     incNoneValues.forEach(value => {
       if (submitData[value] === false) {
         searchQuery[value] = submitData[value];
@@ -102,8 +102,8 @@ const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, 
         <div className="search-label">
           Price range (€)
           <div className="search-input-container">
-            <Input name="minPrice" number placeholder="Min" register={register} maxLength={7} />
-            <Input name="maxPrice" number placeholder="Max" register={register} maxLength={7} />
+            <Input name="minPrice" number placeholder="Min" register={register} setValue={setValue} maxLength={7} />
+            <Input name="maxPrice" number placeholder="Max" register={register} setValue={setValue} maxLength={7} />
           </div>
         </div>
         <Dropdown
@@ -129,22 +129,22 @@ const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, 
           <div className="search-label">
             Property size (m{String.fromCharCode(178)})
             <div className="search-input-container">
-              <Input name="minSize" number placeholder="Min" register={register} maxLength={5} />
-              <Input name="maxSize" number placeholder="Max" register={register} maxLength={5} />
+              <Input name="minSize" number placeholder="Min" register={register} setValue={setValue} maxLength={5} />
+              <Input name="maxSize" number placeholder="Max" register={register} setValue={setValue} maxLength={5} />
             </div>
           </div>
           <div className="search-label">
             Plot size (m{String.fromCharCode(178)})
             <div className="search-input-container">
-              <Input name="minPlot" number placeholder="Min" register={register} maxLength={5} />
-              <Input name="maxPlot" number placeholder="Max" register={register} maxLength={5} />
+              <Input name="minPlot" number placeholder="Min" register={register} setValue={setValue} maxLength={5} />
+              <Input name="maxPlot" number placeholder="Max" register={register} setValue={setValue} maxLength={5} />
             </div>
           </div>
           <div className="search-label">
             No. bedrooms
             <div className="search-input-container">
-              <Input name="minBeds" number placeholder="Min" register={register} maxLength={3} />
-              <Input name="maxBeds" number placeholder="Max" register={register} maxLength={3} />
+              <Input name="minBeds" number placeholder="Min" register={register} setValue={setValue} maxLength={3} />
+              <Input name="maxBeds" number placeholder="Max" register={register} setValue={setValue} maxLength={3} />
             </div>
           </div>
           <div className="search-label search-label-multiselect">
@@ -153,7 +153,11 @@ const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, 
               data={Object.keys(agentMapping)}
               filter='contains'
               onChange={selected => setValue("agents", selected)}
-              showSelectedItemsInList
+              textField={item =>
+                watch("agents")?.includes(item)
+                // show full name if item is not selected selected, don't show "Immobilier" if selected
+                  ? item.replace(" Immobilier", "") : item
+              }
             />
           </div>
           <div className="search-label search-label-long">
@@ -173,7 +177,7 @@ const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, 
             />
           </div>
           <SearchSlider register={register} />
-          <SearchUnknown register={register} />
+          <SearchUnknown register={register} watch={watch} />
         </div>
       </form>
     </div>

--- a/src/components/SearchUnknown.js
+++ b/src/components/SearchUnknown.js
@@ -1,26 +1,24 @@
 import React from 'react';
 
-const SearchUnknown = ({ register }) => {
+import CheckboxOption from './CheckboxOption';
+
+const SearchUnknown = ({ register, watch }) => {
   const checkboxOptions = [
-    { label: "Number of rooms", name: "inc_none_rooms" },
-    { label: "Number of bedrooms", name: "inc_none_beds" },
-    { label: "Property size", name: "inc_none_size" },
-    { label: "Land size", name: "inc_none_plot" },
-    { label: "Location", name: "inc_none_location" }
+    { label: "Number of bedrooms", name: "inc_none_beds", relatedFields: ["minBeds", "maxBeds"] },
+    { label: "Property size", name: "inc_none_size", relatedFields: ["minSize", "maxSize"] },
+    { label: "Land size", name: "inc_none_plot", relatedFields: ["minPlot", "maxPlot"] },
+    { label: "Location", name: "inc_none_location", relatedFields: ["department", "area"] }
   ];
 
   return (
     <div className="include-unknown-container">
       <h4 className="unknown-listings-title">
-        A few listings are missing data, such as number of bedrooms or property size.{"\n"}Do you want to include these listings in your search?
+        A few listings are missing data, such as the size of the property, or where it is located.{"\n"}Do you want to include these listings in your search?
       </h4>
       <h6 className="unknown-listings-subtitle">Include unknown...</h6>
       <div className="checkbox-container">
         {checkboxOptions.map(option => (
-          <label className="checkbox-label" key={option.name}>
-            {option.label}
-            <input type="checkbox" {...register(option.name)} />
-          </label>
+          <CheckboxOption key={option.name} option={option} register={register} watch={watch} />
         ))}
       </div>
     </div>

--- a/src/scss/_media.scss
+++ b/src/scss/_media.scss
@@ -44,6 +44,12 @@
   }
 }
 
+@media screen and (max-width: 960px) {
+  .unknown-listings-title {
+    white-space: unset;
+  }
+}
+
 @media screen and (max-width: 920px) {
   .search-form-container {
     padding: 2.5rem;
@@ -215,10 +221,6 @@
 
   .include-unknown-container {
     margin: 1rem 0 0.5rem 0;
-  }
-
-  .unknown-listings-title {
-    white-space: unset;
   }
 
   .unknown-listings-subtitle {

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -52,9 +52,6 @@ export const getSearchURL = searchQuery => {
   if (searchQuery.inc_none_location === false) {
     query += "&inc_none_location=false";
   }
-  if (searchQuery.inc_none_rooms === false) {
-    query += "&inc_none_rooms=false";
-  }
   if (searchQuery.inc_none_size === false) {
     query += "&inc_none_size=false";
   }


### PR DESCRIPTION
- Update checkboxes so that they uncheck as values are entered into their corresponding inputs (so include unknown bedrooms unchecks as a user enters a value in either the minimum or maximum bedrooms inputs)
- Ensure input values are passed to `inputValue` as numbers, not strings, so the `toLocaleString()` method can display them with commas
- Remove unknown rooms option
- Fix bug with one property having no description