### PR TITLE
Allow listings to be opened in same tab or new tab

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,11 +9,11 @@ import ListingsContainer from "./components/ListingsContainer";
 import LoadingAnimation from "./components/LoadingAnimation";
 import SearchForm from "./components/SearchForm";
 
-// add modal to show more listing information
 // add footer with contact link
 // add error page and ErrorElement to react router config
 // make the search form "advanced" button grow the backround gradually as well as the search box
 // when listings dropdown changes, reset page to 1
+// current when the user opens listing detail page in a new tab, a local storage item is set with the key as the listing's ref, but this doesn't delete - add an expiry and a function to call when the app initially loads to delete any items that have expired
 
 const App = () => {
   const [listings, setListings] = useState([]);

--- a/src/assets/scss/_listings.scss
+++ b/src/assets/scss/_listings.scss
@@ -144,6 +144,8 @@
   z-index: 2;
 
   &:hover {
+    color: #222427;
+    text-decoration: none;
     border: 2px solid rgba(247, 221, 22, 0.8);
     box-shadow:
     rgba(247, 221, 22, 0.27) 0 0 1px 1px,

--- a/src/components/Listing.js
+++ b/src/components/Listing.js
@@ -14,14 +14,30 @@ const Listing = ({ listing }) => {
   const dotRef = useRef();
   const navigate = useNavigate();
 
+  const handleMiddleClick = e => {
+    if (e.button === 1) handleSelectListing(e);
+  }
+
   // ensure listing is only selected if other buttons on the listing are not clicked
   const handleSelectListing = (e) => {
     const otherTargets = ["img-arrow", "img-arrow-glyph", "listing-image-circle", "listing-image-current", "listing-save-container", "heart-icon"];
     const classNames = e.target.classList;
-    for (let className of classNames) {
-      if (otherTargets.indexOf(className) !== -1) return;
+    // e.button === 0 is a left click
+    if (e.button === 0 && !e.ctrlKey) {
+      for (let className of classNames) {
+        if (otherTargets.indexOf(className) !== -1) {
+          e.preventDefault();
+          return;
+        }
+      }
     }
-    navigate(`/listings/${listing.ref}`, { state: listing })
+
+    if (e.button === 0 && !e.ctrlKey) {
+      e.preventDefault();
+      navigate(`/listings/${listing.ref}`, { state: listing });
+    } else {
+      localStorage.setItem(listing.ref, JSON.stringify(listing));
+    }
   }
 
   const getPropertyType = type => {
@@ -52,7 +68,13 @@ const Listing = ({ listing }) => {
   }
 
   return (
-    <div className="listing-container" onClick={handleSelectListing}>
+    <a 
+      className="listing-container"
+      href={`/listings/${listing.ref}`}
+      onContextMenu={handleSelectListing}
+      onClick={handleSelectListing}
+      onMouseDown={handleMiddleClick}
+    >
       <div className="listing-save-container" onClick={handleToggleLike} >
         <i className={`fa-regular fa-heart heart-icon ${isSaved ? "saved" : ""}`} ref={heartRef} />
         <div className={`${isSaved ? "heart-dot saved" : "heart-dot"}`} ref={dotRef}></div>
@@ -115,7 +137,7 @@ const Listing = ({ listing }) => {
           <h5 className="listing-ref">Ref: {listing.ref}</h5>
         </div>
       </div>
-    </div>
+    </a>
   )
 }
 

--- a/src/components/ListingDetail.js
+++ b/src/components/ListingDetail.js
@@ -8,11 +8,14 @@ import ImageControlBar from './ImageControlBar';
 const ListingDetail = () => {
   const [currentImage, setCurrentImage] = useState(0);
   const location = useLocation();
-  const listing = location.state;
+  const listingID = location.pathname.slice(10);
+  const [listing, setListing] = useState(location.state || JSON.parse(localStorage.getItem(listingID)));
 
   useEffect(() => {
     scrollTo(0, "auto");
   }, []);
+
+  if (!listing) return null;
 
   return (
     <div className="listing-detail-page-container">


### PR DESCRIPTION
- Update listing container so that listings can be opened in the same tab or in a new tab/window, including functionality for all 3 mouse buttons including use of the control key for new tab openings
- If listing is opened in the same tab, use React Router's `useNavigate()` method and set the state using React Router
- If listing is opened in new tab/window, save the listing in local storage using the reference as a key, and then retrieve it on the listing detail page
- Note that there is no clean up for local storage yet