### PR TITLE
Update image control bar to always show all images, fix bug with search input

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Search for properties in the Occitanie region"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> -->
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/assets/scss/_listings.scss
+++ b/src/assets/scss/_listings.scss
@@ -304,7 +304,7 @@
 }
 
 .img-arrow-left {
-  left: 0.5rem;
+  left: 0;
 
   span {
     transform: rotate(180deg);
@@ -312,18 +312,27 @@
 }
 
 .img-arrow-right {
-  right: 0.5rem;
+  right: 0;
 }
 
 .listing-image-control-bar {
   position: relative;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem 0.45rem;
   width: 100%;
-  height: 2rem;
+  height: fit-content;
   margin-top: 0.2rem;
+  padding: 0.5rem 1.6rem;
+}
+
+.listing-image-cirlce-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.2rem;
+  height: 1.25rem;
 }
 
 .listing-image-circle {
@@ -338,6 +347,7 @@
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
+  padding: 0 0.1rem;
 
   &:hover {
     background-color: $color-tertiary;
@@ -347,8 +357,8 @@
 }
 
 .listing-image-current {
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.2rem;
+  height: 1.2rem;
 }
 
 .listing-details-container {
@@ -498,8 +508,11 @@
 .listing-detail-page-img {
   position: relative;
   max-width: 100%;
-  height: 100%;
+  width: 100%;
   min-height: 0;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: 0.15rem;
 }
 
 .listing-detail-info-container {

--- a/src/assets/scss/_media.scss
+++ b/src/assets/scss/_media.scss
@@ -7,6 +7,11 @@
   .search-form-container {
     padding: 2.5rem 3.5rem;
   }
+
+  .listing-detail-img-container {
+    max-height: calc(100vh - 4rem); // minus navbar height
+    height: fit-content;
+  }
 }
 
 @media screen and (max-width: 1050px) {
@@ -194,7 +199,7 @@
   }
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 700px) {  ///////////////////////// add hamburger in here
   .hero-text-container {
     padding: 0 0 2rem 0;
   }

--- a/src/assets/scss/_search-form.scss
+++ b/src/assets/scss/_search-form.scss
@@ -100,7 +100,8 @@
 
 .search-input {
   font-size: 1.25rem;
-  width: 6.25rem;
+  width: 6.5rem;
+  min-width: 6.5rem;
   height: 2.5rem;
   line-height: 2.5rem;
   outline: none;

--- a/src/components/ImageControlBar.js
+++ b/src/components/ImageControlBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ImageControlBar = ({ currentImage, listingPhotos, maxImages, setCurrentImage }) => {
+const ImageControlBar = ({ currentImage, listingPhotos, setCurrentImage }) => {
   const handleChangePhoto = direction => {
     if (direction === "R") {
       if (currentImage === listingPhotos.length - 1) {
@@ -19,10 +19,11 @@ const ImageControlBar = ({ currentImage, listingPhotos, maxImages, setCurrentIma
         <span className="img-arrow-glyph">&#x27a4;</span>
       </div>
       {listingPhotos.map((photo, i) => {
-        if ((window.innerWidth < 410 && i > 9) || i > maxImages) return null;
         return i === currentImage
           ? <img src="/bee-image-2.png" key={i} className="listing-image-current" />
-          : <div className="listing-image-circle" key={i} onClick={() => setCurrentImage(i)} />
+          : <div className="listing-image-cirlce-container" key={i}>
+              <div className="listing-image-circle" onClick={() => setCurrentImage(i)} />
+            </div>
         })}
       <div className="img-arrow img-arrow-right" onClick={() => handleChangePhoto("R")}>
         <span className="img-arrow-glyph">&#x27A4;</span>

--- a/src/components/Listing.js
+++ b/src/components/Listing.js
@@ -22,22 +22,25 @@ const Listing = ({ listing }) => {
   const handleSelectListing = (e) => {
     const otherTargets = ["img-arrow", "img-arrow-glyph", "listing-image-circle", "listing-image-current", "listing-save-container", "heart-icon"];
     const classNames = e.target.classList;
-    // e.button === 0 is a left click
-    if (e.button === 0 && !e.ctrlKey) {
-      for (let className of classNames) {
-        if (otherTargets.indexOf(className) !== -1) {
+    
+    for (let className of classNames) {
+      if (otherTargets.indexOf(className) !== -1) {
+        // e.button === 0 is a left click
+        if (e.button === 0 && !e.ctrlKey) {
           e.preventDefault();
-          return;
         }
+        return;
       }
     }
+    
 
-    if (e.button === 0 && !e.ctrlKey) {
-      e.preventDefault();
-      navigate(`/listings/${listing.ref}`, { state: listing });
-    } else {
+    // if (e.button === 0 && !e.ctrlKey) {
+    //   e.preventDefault();
+    //   navigate(`/listings/${listing.ref}`, { state: listing });
+    // } else {
       localStorage.setItem(listing.ref, JSON.stringify(listing));
-    }
+      window.open(`/listings/${listing.ref}`, "_blank", "noreferrer");
+    // }
   }
 
   const getPropertyType = type => {

--- a/src/components/ListingDetail.js
+++ b/src/components/ListingDetail.js
@@ -9,7 +9,8 @@ const ListingDetail = () => {
   const [currentImage, setCurrentImage] = useState(0);
   const location = useLocation();
   const listingID = location.pathname.slice(10);
-  const [listing, setListing] = useState(location.state || JSON.parse(localStorage.getItem(listingID)));
+  // use location.state when opening the listing in the same tab
+  const [listing, setListing] = useState(JSON.parse(localStorage.getItem(listingID)));
 
   useEffect(() => {
     scrollTo(0, "auto");
@@ -24,7 +25,6 @@ const ListingDetail = () => {
         <ImageControlBar
           currentImage={currentImage}
           listingPhotos={listing.photos_hosted}
-          maxImages={listing.photos_hosted.length}
           setCurrentImage={setCurrentImage}
         />
       </div>

--- a/src/components/ListingImage.js
+++ b/src/components/ListingImage.js
@@ -17,7 +17,6 @@ const ListingImage = ({ listing }) => {
             <ImageControlBar
               currentImage={currentImage}
               listingPhotos={listing.photos_hosted}
-              maxImages={14}
               setCurrentImage={setCurrentImage}
             />
           </div>

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -89,8 +89,8 @@ const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, 
         <div className="search-label">
           Price range (€)
           <div className="search-input-container">
-            <Input name="minPrice" number placeholder="Min" register={register} setValue={setValue} maxLength={7} />
-            <Input name="maxPrice" number placeholder="Max" register={register} setValue={setValue} maxLength={7} />
+            <Input name="minPrice" number placeholder="Min" register={register} setValue={setValue} maxLength={9} />
+            <Input name="maxPrice" number placeholder="Max" register={register} setValue={setValue} maxLength={9} />
           </div>
         </div>
         <Dropdown
@@ -116,15 +116,15 @@ const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, 
           <div className="search-label">
             Property size (m{String.fromCharCode(178)})
             <div className="search-input-container">
-              <Input name="minSize" number placeholder="Min" register={register} setValue={setValue} maxLength={5} />
-              <Input name="maxSize" number placeholder="Max" register={register} setValue={setValue} maxLength={5} />
+              <Input name="minSize" number placeholder="Min" register={register} setValue={setValue} maxLength={6} />
+              <Input name="maxSize" number placeholder="Max" register={register} setValue={setValue} maxLength={6} />
             </div>
           </div>
           <div className="search-label">
             Plot size (m{String.fromCharCode(178)})
             <div className="search-input-container">
-              <Input name="minPlot" number placeholder="Min" register={register} setValue={setValue} maxLength={5} />
-              <Input name="maxPlot" number placeholder="Max" register={register} setValue={setValue} maxLength={5} />
+              <Input name="minPlot" number placeholder="Min" register={register} setValue={setValue} maxLength={6} />
+              <Input name="maxPlot" number placeholder="Max" register={register} setValue={setValue} maxLength={6} />
             </div>
           </div>
           <div className="search-label">


### PR DESCRIPTION
- Update the bar underneath all listings to always show all images
- Fix bug with search inputs where the `toLocaleString()` method was including the commas as part of the `maxLength` attribute, so each input had a lower max length than desired
- Update listings to always open a new tab when clicked on, as the search does not yet persist between page changes