### PR TITLE
Update how listings are saved, fetch each page separately

### DIFF
--- a/src/assets/scss/_footer.scss
+++ b/src/assets/scss/_footer.scss
@@ -9,7 +9,7 @@
   background-repeat: no-repeat;
   background-size: cover;
   overflow: hidden;
-  box-shadow: rgb(120, 117, 54) 0px 4px 4px inset;
+  box-shadow: rgb(120, 117, 54) 0px 4px 4px inset, rgb(120, 117, 54) 0px 4px 4px;
   // Allow overlay to show through whilst keeping all text on top
   isolation: isolate;
   padding: 0.5rem 1.5rem;
@@ -19,7 +19,7 @@
     position: absolute;
     width: 100%;
     min-height: 100%;
-    background: linear-gradient(90deg, rgba(201, 174, 255, 0.85) 5%, rgba(200, 239, 255, 0.87) 30%, rgba(200, 239, 255, 0.92));
+    background: linear-gradient(90deg, rgba(201, 174, 255, 0.85) 5%, rgba(180, 232, 252, 0.87) 30%, rgba(184, 235, 255, 0.92));
     left: 0;
     top: 0;
     z-index: -1;

--- a/src/assets/scss/_homepage.scss
+++ b/src/assets/scss/_homepage.scss
@@ -1,7 +1,7 @@
 .hero-section {
   position: relative;
   width: 100%;
-  height: calc(100vh - 4rem);
+  height: calc(100vh - 7.5rem);
   background-color: $color-secondary;
   bottom: 0;
 }
@@ -79,7 +79,7 @@
     content: "";
     height: 1.3rem;
     width: calc(100% + 0.75rem);
-    background-color: $color-highlight;
+    background-color: $color-primary-highlight;
     border-top: 9px solid $color-primary;
     z-index: -1;
     transform: rotate(-2deg);
@@ -117,9 +117,9 @@
   font-size: 1.75rem;
   font-weight: 500;
   width: 23rem;
-  color: #322;
+  color: $color-text;
   background-color: $color-primary;
-  border: 3px solid $color-highlight;
+  border: 3px solid $color-primary-highlight;
   border-radius: 0.5rem;
   outline: none;
   text-align: center;
@@ -129,14 +129,14 @@
   margin-top: 2rem;
 
   &:visited {
-    color: #322;
+    color: $color-text;
     background-color: $color-primary;
-    border: 3px solid $color-highlight;
+    border: 3px solid $color-primary-highlight;
   }
 
   &:hover {
-    color: #322;
-    background-color: $color-highlight;
+    color: $color-text;
+    background-color: $color-primary-highlight;
     border: 3px solid $color-primary;
     text-decoration: none;
     transition: 300ms ease all;

--- a/src/assets/scss/_listings.scss
+++ b/src/assets/scss/_listings.scss
@@ -8,6 +8,7 @@
   padding: 2rem;
   background: url("../../../public/small-hexagons.jpg");
   background-size: cover;
+  box-shadow: rgb(56, 55, 39) 0px 1px 3px inset;
 
   &::before {
     content: "";
@@ -50,7 +51,7 @@
   justify-content: center;
   align-items: center;
   gap: 0.5rem;
-  min-height: calc(100vh - 4rem);
+  min-height: calc(100vh - 7.5rem);
   padding: 2.5rem;
 }
 
@@ -67,7 +68,7 @@
   font-weight: 500;
   color: $color-text;
   background-color: $color-primary;
-  border: 3px solid $color-highlight;
+  border: 3px solid $color-primary-highlight;
   border-radius: 0.5rem;
   outline: none;
   text-align: center;
@@ -83,12 +84,12 @@
   &:visited {
     color: $color-text;
     background-color: $color-primary;
-    border: 3px solid $color-highlight;
+    border: 3px solid $color-primary-highlight;
   }
 
   &:hover {
     color: $color-text;
-    background-color: $color-highlight;
+    background-color: $color-primary-highlight;
     border: 3px solid $color-primary;
     text-decoration: none;
     transition: 300ms ease all;

--- a/src/assets/scss/_media.scss
+++ b/src/assets/scss/_media.scss
@@ -366,6 +366,7 @@
     align-items: center;
     justify-content: center;
     gap: 1rem;
+    text-align: center;
   }
 
   .sorting-dropdown-container {
@@ -465,7 +466,7 @@
 
   .search-results-container {
     border-radius: 0;
-    padding: 2rem 0.5rem;
+    padding: 2rem 1.5rem;
   }
 }
 

--- a/src/assets/scss/_navbar.scss
+++ b/src/assets/scss/_navbar.scss
@@ -141,7 +141,7 @@
 
 .hamburger-menu {
   position: absolute;
-  background-color: $color-highlight;
+  background-color: $color-primary-highlight;
   width: 100%;
   border: 3px solid $color-primary;
   border-radius: 0.5rem;

--- a/src/assets/scss/_search-form.scss
+++ b/src/assets/scss/_search-form.scss
@@ -2,7 +2,8 @@
   position: relative;
   background-color: $color-secondary;
   width: 100%;
-  min-height: calc(100vh + 1rem);
+  min-height: 100vh;
+  box-shadow: rgba(120, 117, 54, 0.4) 0px 1px 7px inset;
   overflow: hidden;
   z-index: 49;
 }
@@ -27,7 +28,7 @@
   position: relative;
   font-family: "ChelseaMarket", "Raleway", sans-serif;
   font-size: 2.5rem;
-  color: $color-highlight;
+  color: $color-primary-highlight;
   font-weight: bold;
   text-align: center;
   margin-top: 5rem;
@@ -53,7 +54,7 @@
   width: 90%;
   max-width: 70rem;
   min-height: 11.5rem;
-  background-color: $color-highlight;
+  background-color: $color-primary-highlight;
   background: url("../../../public/honeycombbg.jpg");
   background-position: top center;
   border-radius: 0.6rem;
@@ -291,9 +292,9 @@
   color: white;
   width: 12rem;
   height: 4rem;
-  color: #322;
+  color: $color-text;
   background-color: $color-primary;
-  border: 3px solid $color-highlight;
+  border: 3px solid $color-primary-highlight;
   border-radius: 0.5rem;
   outline: none;
   left: 50%;
@@ -311,8 +312,8 @@
 
   &:active,
   &:hover {
-    color: #322;
-    background-color: $color-highlight;
+    color: $color-text;
+    background-color: $color-primary-highlight;
     border: 3px solid $color-primary;
     transition: 300ms ease all;
     -webkit-transition: 300ms ease all;

--- a/src/assets/scss/_sorting-dropdown.scss
+++ b/src/assets/scss/_sorting-dropdown.scss
@@ -19,7 +19,7 @@
 
 .sorting-dropdown {
   position: absolute;
-  background-color: $color-highlight;
+  background-color: $color-primary-highlight;
   width: 100%;
   border: 3px solid $color-primary;
   border-radius: 0.5rem;

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -1,6 +1,5 @@
 // colors
 $color-primary: rgb(247, 221, 22);
-$color-highlight: rgb(254, 254, 176);
 $color-primary-highlight: rgb(254, 254, 176);
 
 $color-secondary: rgb(200, 239, 255);

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -21,7 +21,7 @@ const Home = () => {
           {/* Say goodbye to endless scrolling and countless website tabs -  */}
           ImmoBee is here to <span className="hero-text-highlight">simplify your property search</span> and guide you towards finding the perfect place to call home. With an extensive database comprising 20 local agents, ImmoBee is your one-stop destination for hassle-free house hunting in Occitanie.
         </p>
-        <Link className="btn-hero" to="/search">Search now</Link>
+        <Link className="btn-hero" to="/search/1">Search now</Link>
       </div>
     </div>
   )

--- a/src/components/Listing.js
+++ b/src/components/Listing.js
@@ -8,7 +8,7 @@ import ListingImage from './ListingImage';
 const Listing = ({ listing }) => {
   // link_url is the unique identifier for each listing
   const [isSaved, setIsSaved] = useState(
-    JSON.parse(localStorage.getItem("listings"))?.some(savedListing => savedListing?.link_url === listing.link_url) || null
+    JSON.parse(localStorage.getItem("savedListings"))?.some(savedListing => savedListing?.link_url === listing.link_url) || null
   );
   const heartRef = useRef();
   const dotRef = useRef();
@@ -58,17 +58,17 @@ const Listing = ({ listing }) => {
     heartRef.current.classList.toggle("saved");
     dotRef.current.classList.toggle("saved");
 
-    const savedListings = JSON.parse(localStorage.getItem("listings"));
+    const savedListings = JSON.parse(localStorage.getItem("savedListings"));
     
     if (savedListings?.length) {
       if (isSaved) {
         const filteredListings = savedListings.filter(savedListing => savedListing.link_url !== listing.link_url);
-        localStorage.setItem("listings",  JSON.stringify([...filteredListings]));
+        localStorage.setItem("savedListings",  JSON.stringify([...filteredListings]));
       } else {
-        localStorage.setItem("listings", JSON.stringify([...savedListings, listing]));
+        localStorage.setItem("savedListings", JSON.stringify([...savedListings, listing]));
       }
     } else {
-      localStorage.setItem("listings", JSON.stringify([listing]));
+      localStorage.setItem("savedListings", JSON.stringify([listing]));
     }
   }
 

--- a/src/components/SavedListings.js
+++ b/src/components/SavedListings.js
@@ -3,14 +3,14 @@ import React, { useState } from 'react';
 import ListingsContainer from './ListingsContainer';
 
 const SavedListings = () => {
-  const [listings, setListings] = useState(JSON.parse(localStorage.getItem("listings")) || []);
+  const [listings, setListings] = useState(JSON.parse(localStorage.getItem("savedListings")) || []);
 
   return (
     <div className="saved-listings-page-container">
       <ListingsContainer
-        listings={listings}
+        listingIDs={listings}
         noListingsFound={!listings.length}
-        setListings={setListings}
+        setListingIDs={setListings}
       />
     </div>
   )

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -14,7 +14,7 @@ import SearchSlider from './SearchSlider';
 import SearchTextarea from './SearchTextarea';
 import SearchUnknown from './SearchUnknown';
 
-const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, setNoListingsFound, setSearch, setSearchQuery }) => {
+const SearchForm = ({ search, setListingIDs, setLoadingListings, setLoadingTimer, setNoListingsFound, setSearch, setSearchQuery }) => {
   const { register, handleSubmit, setValue, watch } = useForm();
   const [locationChoices, setLocationChoices] = useState([]);
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -23,11 +23,13 @@ const SearchForm = ({ search, setListings, setLoadingListings, setLoadingTimer, 
   const navigate = useNavigate();
 
   const onSubmit = submitData => {
-    navigate("/search");
+    localStorage.removeItem("sortingBy"); // sortingDropdown seems to be accessing this before it is removed
+    localStorage.removeItem("listingIDs");
+    navigate("/search/1");
     if (search) return;
     setLoadingListings(true);
     setLoadingTimer(Date.now())
-    setListings([]);
+    setListingIDs([]);
     setNoListingsFound(false);
     setSearch(true);
     const searchQuery = {};

--- a/src/components/SortingDropdown.js
+++ b/src/components/SortingDropdown.js
@@ -1,12 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from "react-router-dom";
 
-const SortingDropdown = ({ listings, setListings }) => {
+const SortingDropdown = ({ listingIDs, setListingIDs }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const dropdownRef = useRef();
   const dropdownItems = ["Price up", "Price down", "Agent A-Z", "Agent Z-A", "House size up", "House size down", "Garden size up", "Garden size down"];
-  const [sortingBy, setSortingBy] = useState();
+  const [sortingBy, setSortingBy] = useState(JSON.parse(localStorage.getItem("sortingBy")) || null);
 
   const renderArrow = direction => {
     return <span className={`dropdown-arrow dropdown-${direction}-arrow`}>{"\u279C"}</span>
@@ -50,16 +50,24 @@ const SortingDropdown = ({ listings, setListings }) => {
     sort = sort.join(" ");
     const directionArrow = direction === "up" ? "\u21c8" : direction === "down" ? "\u21ca" : direction;
     setSortingBy(sort + " " + directionArrow);
+    localStorage.removeItem("sortingBy");
+    localStorage.setItem("sortingBy", JSON.stringify(sort + " " + directionArrow));
+    
+    localStorage.removeItem("listingIDs");
+    let sortedListings;
 
     if (direction === "A-Z") {
-      setListings([...listings].sort((a, b) => a[sortMapping[sort]].toUpperCase() > b[sortMapping[sort]].toUpperCase() ? 1 : -1));
+      sortedListings = [...listingIDs].sort((a, b) => a[sortMapping[sort]].toUpperCase() > b[sortMapping[sort]].toUpperCase() ? 1 : -1);
     } else if (direction === "Z-A") {
-      setListings([...listings].sort((a, b) => a[sortMapping[sort]].toUpperCase() < b[sortMapping[sort]].toUpperCase() ? 1 : -1));
+      sortedListings = [...listingIDs].sort((a, b) => a[sortMapping[sort]].toUpperCase() < b[sortMapping[sort]].toUpperCase() ? 1 : -1);
     } else if (direction === "up") {
-      setListings([...listings].sort((a, b) => a[sortMapping[sort]] > b[sortMapping[sort]] ? 1 : -1));
+      sortedListings = [...listingIDs].sort((a, b) => a[sortMapping[sort]] > b[sortMapping[sort]] ? 1 : -1);
     } else {
-      setListings([...listings].sort((a, b) => a[sortMapping[sort]] < b[sortMapping[sort]] ? 1 : -1));
+      sortedListings = [...listingIDs].sort((a, b) => a[sortMapping[sort]] < b[sortMapping[sort]] ? 1 : -1);
     }
+
+    setListingIDs(sortedListings);
+    localStorage.setItem("listingIDs", JSON.stringify(sortedListings));
 
     // reset page to 1 whenever sorting type changes
     navigate(location.pathname.slice(0, location.pathname.lastIndexOf("/")) + "/1");

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -27,4 +27,4 @@ export const agentMapping = {
   "Time and Stone Immobilier": "time",
 }
 
-export const baseURL = "https://suspiciousleaf.pythonanywhere.com/search_results";
+export const baseURL = "https://suspiciousleaf.pythonanywhere.com";

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -67,10 +67,7 @@ export const getSearchURL = searchQuery => {
   
   console.log(query);
 
-  // save the search string to local storage
-  localStorage.setItem("searchQuery", query);
-
-  return query;
+  return "/search_results" + query;
 }
 
 export const scrollTo = (top = 0, behavior = "smooth") => window.scrollTo({top: top, behavior: behavior });


### PR DESCRIPTION
- Replace `listings` with `listingIDs` - `listingIDs` contains a bare bones version of listings that is missing most of the data in order to save a search in localstorage so that listings persist when the user refreshes the page or opens a new tab
- Save the current sorting option to localstorage to re-populate the "Sort by" button if the user refreshes the page
- Update the functionality as much as possible to accommodate these changes, though this is just the first of several PRs that will update this logic. Now that the backend has been updated, this first commit is necessary so that users can keep using the site, otherwise the search doesn't function at all.