### PR TITLE
Update scroll behavior since adding fetch requests for each page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { baseURL } from './data';
 
@@ -18,25 +17,11 @@ const App = () => {
   const [search, setSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState([]);
   const [showSearchResults, setShowSearchResults] = useState(false);
-  const { currentPage } = useParams();
-  const location = useLocation();
-  const navigate = useNavigate();
   
   useEffect(() => {
     if (!noListingsFound && !listingIDs?.length) {
-      console.log("The current page is", currentPage);
       setListingIDs(JSON.parse(localStorage.getItem("listingIDs")));
       setShowSearchResults(true);
-
-      // check if this is running on saved listings page - might be redundant
-      const isSavedListingsPage = location.pathname.startsWith("/saved-listings");
-      console.log(location.pathname)
-      setTimeout(() => {
-        window.scrollTo({
-          top: isSavedListingsPage ? 0 : document.querySelector(".search-results-container")?.offsetTop - 63 || 0,
-          behavior: "smooth",
-        });
-      }, 0);
     }
   }, []);
 
@@ -47,11 +32,9 @@ const App = () => {
         .then(data => {
           // sort listings by increasing price initially
           const sortedListings = data?.length ? data.sort((a, b) => a.price > b.price ? 1 : -1) : [];
-          console.log(sortedListings.length)
           setListingIDs(sortedListings);
           // save array of shortened listings to local storage
           localStorage.setItem("listingIDs", JSON.stringify(sortedListings));
-          console.log(data)
           setNoListingsFound(!data?.length);
           setQueryURL(null);
           setShowSearchResults(true);
@@ -89,7 +72,7 @@ const App = () => {
           setSearchQuery={setSearchQuery}
         />
 
-        {showSearchResults &&
+        {/* {showSearchResults && */}
           <ListingsContainer
             listingIDs={listingIDs}
             noListingsFound={noListingsFound}
@@ -98,7 +81,7 @@ const App = () => {
             setListingIDs={setListingIDs}
             setLoadingListings={setLoadingListings}
           />
-        }
+        {/* } */}
       </div>
     </>
   );

--- a/src/assets/scss/_contact.scss
+++ b/src/assets/scss/_contact.scss
@@ -46,7 +46,7 @@
 
 .letter-send {
   position: relative;
-  background-color: rgba(112, 65, 207, 0.23);
+  background-color: rgba(112, 65, 207, 0.4);
   max-width: 100%;
   height: 100%;
   max-height: 28rem;

--- a/src/assets/scss/_listings.scss
+++ b/src/assets/scss/_listings.scss
@@ -120,9 +120,30 @@
   }
 }
 
+.listing-container-placeholder {
+  position: relative;
+  font-family: "ChelseaMarket", "Raleway", sans-serif;
+  display: flex;
+  flex-direction: column;
+  width: 25rem;
+  height: 27rem;
+  color: #222427;
+  background-color: rgb(253, 253, 252);
+  background: url("../../../public/watercolorbg.jpg");
+  background-size: cover;
+  background-position: center 50%;
+  border: 2px solid rgb(202, 180, 246);
+  border-radius: 0.5rem;
+  box-shadow:
+    rgba(112, 65, 207, 0.27) 1px 1px,
+    rgba(112, 65, 207, 0.23) 4px 4px,
+    rgba(112, 65, 207, 0.18) 8px 8px,
+    rgba(112, 65, 207, 0.13) 12px 12px;
+}
+
 .listing-container {
   position: relative;
-  font-family: 'Work Sans', sans-serif;
+  font-family: "ChelseaMarket", "Raleway", sans-serif;
   display: flex;
   flex-direction: column;
   width: 25rem;

--- a/src/components/Listing.js
+++ b/src/components/Listing.js
@@ -33,16 +33,16 @@ const Listing = ({ listing }) => {
       }
     }
     
-
+    // if user left clicks, open listing in current tab using navigate
+    // if they middle or right click to open in new tab, set the listing in local storage to retrieve in new tab
     if (e.button === 0 && !e.ctrlKey) {
       e.preventDefault();
-    }
-    
-    //   navigate(`/listings/${listing.ref}`, { state: listing });
-    // } else {
+      window.history.pushState({ prevPage: "listing" }, '');
+      navigate(`/listings/${listing.ref}`, { state: listing });
+    } else {
       localStorage.setItem(listing.ref, JSON.stringify(listing));
-      window.open(`/listings/${listing.ref}`, "_blank", "noreferrer");
-    // }
+    }
+    localStorage.setItem("scrollPosition", window.scrollY);
   }
 
   const getPropertyType = type => {

--- a/src/components/ListingDetail.js
+++ b/src/components/ListingDetail.js
@@ -10,7 +10,7 @@ const ListingDetail = () => {
   const location = useLocation();
   const listingID = location.pathname.slice(10);
   // use location.state when opening the listing in the same tab
-  const [listing, setListing] = useState(JSON.parse(localStorage.getItem(listingID)));
+  const [listing, setListing] = useState(location.state || JSON.parse(localStorage.getItem(listingID)));
 
   useEffect(() => {
     scrollTo(0, "auto");
@@ -21,7 +21,7 @@ const ListingDetail = () => {
   return (
     <div className="listing-detail-page-container">
       <div className="listing-detail-img-container">
-        <img src={listing.photos_hosted[currentImage]} className="listing-detail-page-img" alt="listing image" />
+        <img src={listing.photos_hosted[currentImage]} className="listing-detail-page-img" alt="listing" />
         <ImageControlBar
           currentImage={currentImage}
           listingPhotos={listing.photos_hosted}


### PR DESCRIPTION
Update scroll behavior so that:
- If the user clicks on a listing and then goes back to the search results, their scroll position is restored
- When the user clicks on a page number at the bottom, the page scrolls smoothly to the top of the search results
- When a search is performed, the page smoothly scrolls down to the search results

To do: if user clicks away from the search page and then returns to it, the page should remain at the top