### PR TITLE
Fix bug where sharing a link produces no listing for ListingDetail

### DIFF
--- a/src/components/Listing.js
+++ b/src/components/Listing.js
@@ -38,7 +38,7 @@ const Listing = ({ listing }) => {
     if (e.button === 0 && !e.ctrlKey) {
       e.preventDefault();
       window.history.pushState({ prevPage: "listing" }, '');
-      navigate(`/listings/${listing.ref}`, { state: listing });
+      navigate(`/listings/${listing.id}`, { state: listing });
     } else {
       localStorage.setItem(listing.ref, JSON.stringify(listing));
     }
@@ -75,7 +75,7 @@ const Listing = ({ listing }) => {
   return (
     <a 
       className="listing-container"
-      href={`/listings/${listing.ref}`}
+      href={`/listings/${listing.id}`}
       onContextMenu={handleSelectListing}
       onClick={handleSelectListing}
       onMouseDown={handleMiddleClick}

--- a/src/components/ListingDetail.js
+++ b/src/components/ListingDetail.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
+import { baseURL } from '../data';
 import { scrollTo } from '../utilities';
 
 import ImageControlBar from './ImageControlBar';
@@ -11,6 +12,16 @@ const ListingDetail = () => {
   const listingID = location.pathname.slice(10);
   // use location.state when opening the listing in the same tab
   const [listing, setListing] = useState(location.state || JSON.parse(localStorage.getItem(listingID)));
+
+  // If the listing page has been shared or copied to another browser, there will be nothing in state or local storage
+  useEffect(() => {
+    if (!listing) {
+      fetch(`${baseURL}/full_listings?id=${listingID}`)
+      .then(res => res.json())
+      .then(data => setListing(data[0] || null))
+      .catch(err => console.log(err));
+    }
+  }, [listing]);
 
   useEffect(() => {
     scrollTo(0, "auto");


### PR DESCRIPTION
- Fix the bug where, if a listing detail page is shared or opened in a new tab, it displays null, because no listing is saved in state or in local storage