### PR TITLE
Add context to pass setListingIDs around for improved scroll behavior

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,27 +1,29 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 
 import { baseURL } from './data';
 
 import { getSearchURL } from "./utilities";
+
+import { ListingsContext } from ".";
 
 import ListingsContainer from "./components/ListingsContainer";
 import LoadingAnimation from "./components/LoadingAnimation";
 import SearchForm from "./components/SearchForm";
 
 const App = () => {
-  const [listingIDs, setListingIDs] = useState([]);
   const [loadingListings, setLoadingListings] = useState(false);
   const [loadingTimer, setLoadingTimer] = useState();
   const [noListingsFound, setNoListingsFound] = useState(false);
   const [queryURL, setQueryURL] = useState();
   const [search, setSearch] = useState(false);
   const [searchQuery, setSearchQuery] = useState([]);
-  const [showSearchResults, setShowSearchResults] = useState(false);
-  
+  // const [showSearchResults, setShowSearchResults] = useState(false);
+  const { listingIDs, setListingIDs } = useContext(ListingsContext);
+
   useEffect(() => {
     if (!noListingsFound && !listingIDs?.length) {
       setListingIDs(JSON.parse(localStorage.getItem("listingIDs")));
-      setShowSearchResults(true);
+      // setShowSearchResults(true);
     }
   }, []);
 
@@ -37,7 +39,7 @@ const App = () => {
           localStorage.setItem("listingIDs", JSON.stringify(sortedListings));
           setNoListingsFound(!data?.length);
           setQueryURL(null);
-          setShowSearchResults(true);
+          // setShowSearchResults(true);
           setSearch(false);
         })
         .catch(err => console.error(err));

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -9,7 +9,7 @@ const Footer = () => {
       ImmoBee 2023
     </div>
     <div>
-      <img src="bee-2.png" className="footer-bee" alt="bee" />
+      <img src="/bee-2.png" className="footer-bee" alt="" />
       <Link className="footer-link" to="/contact">Contact us</Link>
     </div>
     </footer>

--- a/src/components/ImageControlBar.js
+++ b/src/components/ImageControlBar.js
@@ -33,7 +33,7 @@ const ImageControlBar = ({ currentImage, listingPhotos, setCurrentImage, setPadd
       </div>
       {listingPhotos.map((photo, i) => {
         return i === currentImage
-          ? <img src="/bee-4.png" key={i} className="listing-image-current" />
+          ? <img src="/bee-4.png" key={i} className="listing-image-current" alt="" />
           : <div className="listing-image-circle-container" key={i}>
               <div className="listing-image-circle" onClick={() => setCurrentImage(i)} />
             </div>

--- a/src/components/ListingDetail.js
+++ b/src/components/ListingDetail.js
@@ -21,7 +21,7 @@ const ListingDetail = () => {
       .then(data => setListing(data[0] || null))
       .catch(err => console.log(err));
     }
-  }, [listing]);
+  }, [listing, listingID]);
 
   useEffect(() => {
     scrollTo(0, "auto");

--- a/src/components/ListingsContainer.js
+++ b/src/components/ListingsContainer.js
@@ -67,7 +67,6 @@ const ListingsContainer = ({ listingIDs, loadingListings, loadingTimer, noListin
     });
   };
 
-
   useEffect(() => {
     if (listingIDs?.length || noListingsFound) {
       if (!currentPage) {
@@ -128,7 +127,7 @@ const ListingsContainer = ({ listingIDs, loadingListings, loadingTimer, noListin
         }
       }
     }
-  }, [currentPage, listings, loadingListings, refHasValue]);
+  }, [currentPage, isSavedListingsPage, listings, loadingListings, refHasValue]);
 
   if (noListingsFound) {
     return (
@@ -158,6 +157,10 @@ const ListingsContainer = ({ listingIDs, loadingListings, loadingTimer, noListin
     // can't return null any more with the fetch request on each page or weird scroll behaviour ensues
     // return null; 
   // }
+
+  if (!listingIDs.length) {
+    return null;
+  }
 
   if (listingIDs?.length && (currentPage > Math.ceil(listingIDs?.length / listingsPerPage))) {
     return <Navigate replace to="/error" />

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,20 +1,30 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { 
   Link,
   useLocation
 } from 'react-router-dom';
 
 import { scrollTo } from '../utilities';
+
 import HamburgerMenu from './HamburgerMenu';
 
+import { ListingsContext } from '..';
+
 const Navbar = () => {
+  const { setListingIDs } = useContext(ListingsContext);
   const location = useLocation();
   const currentPage = location.pathname;
+
+  const handleClick = scrollBehavior => {
+    setListingIDs([]);
+    localStorage.setItem("listingIDs", JSON.stringify([]));
+    scrollTo(0, scrollBehavior);
+  }
 
   return (
     <>
       <nav className="navbar">
-        <Link to="/" className="navbar-logo">
+        <Link to="/" className="navbar-logo" onClick={() => handleClick("auto")}>
           <img src="/logo.png" className="navbar-logo-img" alt="logo" />
           <div className="navbar-logo-text">ImmoBee</div>
         </Link>
@@ -23,7 +33,11 @@ const Navbar = () => {
               Search
               <i className="fa-solid fa-magnifying-glass" />
             </div>
-          : <Link to="/search/1" className={`navbar-link ${currentPage.startsWith("/search") ? "current-page" : ""}`}>
+          : <Link
+              className={`navbar-link ${currentPage.startsWith("/search") ? "current-page" : ""}`}
+              onClick={() => handleClick("smooth")}
+              to="/search/1"
+            >
               Search
               <i className="fa-solid fa-magnifying-glass" />
             </Link>
@@ -33,7 +47,11 @@ const Navbar = () => {
               Saved Listings
               <i className="fa-solid fa-house-circle-check" />
             </div>
-          : <Link to="/saved-listings/1" className={`navbar-link ${currentPage.startsWith("/saved-listings") ? "current-page" : ""}`}>
+          : <Link
+              className={`navbar-link ${currentPage.startsWith("/saved-listings") ? "current-page" : ""}`}
+              onClick={() => handleClick("auto")}
+              to="/saved-listings/1"
+            >
               Saved Listings
               <i className="fa-solid fa-house-circle-check" />
             </Link>

--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,21 @@ import SavedListings from './components/SavedListings';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 
-// setListingIDs needs to be sent to the navbar so that it can be reset to [] when the user clicks any button in the navbar
-// for this, I will use context - send setListingIDs to App and Navbar
+export const ListingsContext = React.createContext();
+
+export const ListingsProvider = ({ children }) => {
+  const [listingIDs, setListingIDs] = React.useState([]);
+
+  return (
+    <ListingsContext.Provider value={{ listingIDs, setListingIDs }}>
+      {children}
+    </ListingsContext.Provider>
+  );
+};
 
 root.render(
   <BrowserRouter>
+    <ListingsProvider>
     <div className="page-container">
       <Navbar/>
       <Routes>
@@ -38,5 +48,6 @@ root.render(
       </Routes>
       <Footer />
     </div>
+    </ListingsProvider>
   </BrowserRouter>
 );


### PR DESCRIPTION
- Create context to send to Navbar and App, in order to setListingIDs to an empty array if the user clicks around in the navbar, which means when they return to the search page, it no longer shows the previous search results
- Comment out `setShowSearchResults` until I can determine the best way to show/hide listings