### PR TITLE
Add bee spinner while search form loads

### DIFF
--- a/src/assets/scss/_animations.scss
+++ b/src/assets/scss/_animations.scss
@@ -1917,3 +1917,22 @@
     transform: rotate(360deg);
   }
 }
+
+// Loading bee
+@keyframes rotate-bee-small {
+  0% {
+    transform: rotate(0deg) translate(6.2rem) rotate(92deg);
+  }
+  100% {
+    transform: rotate(360deg) translate(6.2rem) rotate(92deg);
+  }
+}
+
+@-webkit-keyframes rotate-bee-small {
+  0% {
+    transform: rotate(0deg) translate(6.2rem) rotate(92deg);
+  }
+  100% {
+    transform: rotate(360deg) translate(6.2rem) rotate(92deg);
+  }
+}

--- a/src/assets/scss/_error.scss
+++ b/src/assets/scss/_error.scss
@@ -1,6 +1,6 @@
 .error-page-container {
   width: 100%;
-  height: calc(100vh - 4rem);
+  height: calc(100vh - 4rem - 3rem);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -9,63 +9,19 @@
 }
 
 .error-bee-route-container {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   width: 24rem;
   height: 24rem;
-  border-radius: 50%;
+  margin: 0;
 }
 
 .error-bee-border {
-  position: absolute;
   width: 24rem;
   height: 24rem;
-  overflow: hidden;
-  mask: conic-gradient(from 90deg,
-    rgba(0, 0, 0, 0) 0%,
-    rgba(0, 0, 0, 0) 30%,
-    rgba(0, 0, 0, 0.05) 60%,
-    rgba(0, 0, 0, 0.1) 70%,
-    rgba(0, 0, 0, 0.2) 80%,
-    rgba(0, 0, 0, 0.25) 85%,
-    rgba(0, 0, 0, 0.4) 90%,
-    rgba(0, 0, 0, 0.75) 95%,
-    rgb(0, 0, 0) 100%
-  );
   animation: 9s linear infinite bee-trail;
   -webkit-animation: 9s linear infinite bee-trail;
-
-  &::before {
-    content: "";
-    position: absolute;
-    border: 2px dashed $color-tertiary;
-    border-radius: 50%;
-    transform: rotate(30deg);
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-  }
-
-  &::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    transform: rotate(60deg);
-  }
 }
 
 .error-bee {
-  position: absolute;
-  width: 2.5rem;
-  height: 2.5rem;
-  background: url("../../../public/bee-1.png");
-  background-size: cover;
-  border-radius: 50%;
   animation: rotate-bee 9s linear infinite;
   -webkit-animation: rotate-bee 9s linear infinite;
 }

--- a/src/assets/scss/_loading.scss
+++ b/src/assets/scss/_loading.scss
@@ -529,3 +529,83 @@
     left: -0.3rem;
   }
 }
+
+
+// Loading search form screen
+.loading-bee-container {
+  .hero-section-search {
+    display: flex;
+    justify-content: center;
+  }
+}
+
+.loading-bee-route-container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 12rem;
+  height: 12rem;
+  border-radius: 50%;
+  z-index: 250;
+  margin-top: 10rem;
+}
+
+.loading-bee-border {
+  position: absolute;
+  width: 12rem;
+  height: 12rem;
+  overflow: hidden;
+  mask: conic-gradient(from 90deg,
+    rgba(0, 0, 0, 0) 0%,
+    rgba(0, 0, 0, 0) 30%,
+    rgba(0, 0, 0, 0.05) 60%,
+    rgba(0, 0, 0, 0.1) 70%,
+    rgba(0, 0, 0, 0.2) 80%,
+    rgba(0, 0, 0, 0.25) 85%,
+    rgba(0, 0, 0, 0.4) 90%,
+    rgba(0, 0, 0, 0.75) 95%,
+    rgb(0, 0, 0) 100%
+  );
+  animation: 4s linear infinite bee-trail;
+  -webkit-animation: 4s linear infinite bee-trail;
+
+  &::before {
+    content: "";
+    position: absolute;
+    border: 2px dashed $color-tertiary;
+    border-radius: 50%;
+    transform: rotate(30deg);
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: rotate(60deg);
+  }
+}
+
+.loading-bee {
+  position: absolute;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: url("../../../public/bee-1.png");
+  background-size: cover;
+  border-radius: 50%;
+  animation: rotate-bee-small 4s linear infinite;
+  -webkit-animation: rotate-bee-small 4s linear infinite;
+}
+
+.loading-bee-title {
+  font-family: "ChelseaMarket", "Raleway", sans-serif;
+  font-size: 1.75rem;
+  width: 100%;
+  text-align: center;
+}

--- a/src/assets/scss/_reset.scss
+++ b/src/assets/scss/_reset.scss
@@ -28,7 +28,7 @@ label {
 }
 
 .main-content-container {
-  // account for height of navbar
-  min-height: calc(100vh - 3rem);
+  // account for height of navbar and footer
+  min-height: calc(100vh - 4rem - 3rem);
   background-color: $color-secondary-highlight;
 }

--- a/src/assets/scss/_search-form.scss
+++ b/src/assets/scss/_search-form.scss
@@ -2,7 +2,8 @@
   position: relative;
   background-color: $color-secondary;
   width: 100%;
-  min-height: 100vh;
+  // must always keep scrollbar in view
+  min-height: calc(100vh - 3rem);
   box-shadow: rgba(120, 117, 54, 0.4) 0px 1px 7px inset;
   overflow: hidden;
   z-index: 49;
@@ -10,7 +11,7 @@
 
 .hero-section-search-overlay {
   position: absolute;
-  background-color: rgba(138, 170, 179, 0.525);
+  background: linear-gradient(rgb(110, 182, 202), rgba(141, 201, 217, 0.7), rgba(156, 189, 198, 0.7), rgba(138, 170, 179, 0.5));
   width: 100%;
   height: 100%;
   z-index: 10;
@@ -183,9 +184,11 @@
 }
 
 .search-dropdown-locked {
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   background-color: rgb(242, 237, 237);
   color: rgb(148, 147, 147);
+  border: 1px solid rgb(236, 231, 231);
+  padding: 0;
   cursor: default;
 
   &:hover,

--- a/src/components/ErrorPage.js
+++ b/src/components/ErrorPage.js
@@ -3,9 +3,9 @@ import React from 'react';
 const ErrorPage = () => {
   return (
     <div className="error-page-container">
-      <div className="error-bee-route-container">
-      <div className="error-bee-border" />
-      <div className="error-bee" />
+      <div className="loading-bee-route-container error-bee-route-container">
+      <div className="loading-bee-border error-bee-border" />
+      <div className="loading-bee error-bee" />
         <h1 className="error-page-title">Oops!</h1>
         <h1 className="error-page-subtitle">
           Sorry, this page{"\n"}does not exist.

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -81,7 +81,21 @@ const SearchForm = ({ search, setListingIDs, setLoadingListings, setLoadingTimer
     .catch(err => console.error(err));
   }, []);
 
-  if (!locationChoices.length) return null;
+  if (!locationChoices.length) {
+    return (
+      <div className="loading-bee-container">
+        <div className="hero-section-search">
+          <img src="/search-bg.jpg" className="hero-section-search-img" alt="" />
+          <div className="hero-section-search-overlay" />
+          <div className="loading-bee-route-container">
+            <div className="loading-bee-border" />
+            <div className="loading-bee" />
+            <h1 className="loading-bee-title">Loading...</h1>
+          </div>
+        </div>
+      </div>
+    )
+  }
   
   return (
     <div className="hero-section-search">

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -25,6 +25,10 @@ export const getSearchURL = searchQuery => {
 
   if (queryParams.indexOf("area") !== -1) {
     const areaQuery = searchQuery.area.map(area => {
+      const town = area.split(", ")[0].replaceAll(" ", "%20");
+      const postcode = area.split(", ")[1];
+      // return `${postcode}-${town}`;
+
       return area.split(",")[0].replaceAll(" ", "%20")
     }).join(",");
     query += `&town=${areaQuery}&search_radius=${searchQuery.search_radius || "1"}`;


### PR DESCRIPTION
- Add a bee spinner to the search form while the location choices are loading
- Update the page container heights so that pages are slightly shorter (and the error page is now 100vh including nav bar and footer)
- Fix small bug with the search form where the "Select town OR department" warning message was larger than its container for some screen sizes
- In the near future, the search query will take `11000-carcassonne` instead of just `carcassonne` as part of the comma separated list of town names, to distinguish between towns with the same name but different postcodes. That logic has been added but commented out until the database changes have been merged.
- Add a gradient to the search form background so that the background looks more vibrant when the search form is expanded