### PR TITLE
Make sort more efficient, fix bug with sorting dropdown

### DIFF
--- a/src/components/ListingsContainer.js
+++ b/src/components/ListingsContainer.js
@@ -43,14 +43,23 @@ const ListingsContainer = ({ listingIDs, loadingListings, loadingTimer, noListin
     // On the saved listings page, the entire listing is currently saved instead of the ID
     // No need to re-fetch those listings
     if (isSavedListingsPage) {
-      setListings(listingIDs.slice(currentOffset, currentOffset + 12));
+      const newListingIDs = listingIDs.slice(currentOffset, currentOffset + 12).map(listing => listing.listingID);
+      const currentListingIDs = listings.map(listing => listing.listingID);
+      if (JSON.stringify(currentListingIDs) !== JSON.stringify(newListingIDs)) {
+        setListings(listingIDs.slice(currentOffset, currentOffset + 12));
+      }
       return;
     }
 
     const fullListingsToFetch = listingIDs
-      .slice(currentOffset, currentOffset + 12)
-      .map((listing) => listing.listingID)
-      .toString();
+    .slice(currentOffset, currentOffset + 12)
+    .map((listing) => listing.listingID)
+    .toString();
+
+    // Don't perform a new query if the new results will be the same as the current results
+    const currentFetchedListings = listings.map(listing => listing.listingID).toString();
+    if (currentFetchedListings === fullListingsToFetch) return;
+
     
     fetch(`${baseURL}/full_listings?id=${fullListingsToFetch}`)
       .then(res => res.json())
@@ -58,7 +67,7 @@ const ListingsContainer = ({ listingIDs, loadingListings, loadingTimer, noListin
         setListings(data);
       })
       .catch(err => console.log(err));
-  }, [currentOffset, isSavedListingsPage, listingIDs]);
+  }, [currentOffset, isSavedListingsPage, listingIDs, listings]);
 
   const renderListings = () => {
     const listingsToRender = listings;

--- a/src/components/SortingDropdown.js
+++ b/src/components/SortingDropdown.js
@@ -86,8 +86,20 @@ const SortingDropdown = ({ listingIDs, setListingIDs }) => {
   }
 
   useEffect(() => {
+    // If the user navigates to the saved listings page after sorting from the search results, sortingBy retains its value
+    if (sortingBy) {
+      let currentSort = sortingBy;
+      // const currentSort = sortingBy.indexOf("⇊") ? sortingBy.split(" ")
+      if (sortingBy.indexOf("⇊")) {
+        currentSort = sortingBy.replace("⇊", "down");
+      } else if (sortingBy.indexOf("⇈")) {
+        currentSort = sortingBy.replace("⇊", "up");
+      }
+      handleSort(currentSort);
+    }
     document.addEventListener("click", handleCloseDropdown);
     return () => document.removeEventListener("click", handleCloseDropdown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (


### PR DESCRIPTION
- Improve efficiency of sorting drop down by only querying for new listings if there is more than 1 page of listings (e.g. if a user performs a search that yields 7 results, and then they keep sorting those results by price, agent, etc., a new query is not made for each sort)
- Fix bug where if the user had sorted the listings on the search results page, and then navigated to the saved listings page, the dropdown displayed the current sort, but the results were not sorted