### PR TITLE
Delete listings from local storage after 48 hours

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,22 @@ const App = () => {
   const [searchQuery, setSearchQuery] = useState([]);
   const { listingIDs, setListingIDs } = useContext(ListingsContext);
 
+  // Delete previous search results if more than 2 days old
+  useEffect(() => {
+    const currentTime = new Date();
+    var dateOffset = (24 * 60 * 60 *1000) * 2;
+    const date48HoursAgo = currentTime.getTime() - dateOffset;
+
+    const lastSearchTime = localStorage.getItem("lastSearchTime")
+    if (!lastSearchTime) return;
+
+    if (Number(lastSearchTime) < date48HoursAgo) {
+      console.log("Search results too old, removing listingIDs")
+      localStorage.removeItem("lastSearchTime")
+      localStorage.removeItem("listingIDs")
+    }
+  }, []);
+
   useEffect(() => {
     if (!noListingsFound && !listingIDs?.length) {
       setListingIDs(JSON.parse(localStorage.getItem("listingIDs")));
@@ -41,6 +57,9 @@ const App = () => {
           setListingIDs(sortedListings);
           // save array of shortened listings to local storage
           localStorage.setItem("listingIDs", JSON.stringify(sortedListings));
+          // Set lastSearchTime in order to ensure listings expire after 48 hours
+          const timeNow = new Date();
+          localStorage.setItem("lastSearchTime", JSON.stringify(timeNow.getTime()));
           setNoListingsFound(!sortedListings?.length);
           setQueryURL(null);
           setSearch(false);

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -12,7 +12,7 @@ export const getSearchURL = (searchQuery, agentChoices) => {
   }
   
   // only search by department if area has no value
-  if (queryParams.includes("department") && queryParams.includes("area")) {
+  if (queryParams.includes("department") && !queryParams.includes("area")) {
     // only send the department number in the query string (i.e. "11" not "Aude (11)"")
     const departments = searchQuery.department.map(dept => {
       return dept.split("(")[1].split(")")[0];


### PR DESCRIPTION
- If user visits site 48+ hours after performing a search, delete the listings from their local storage
- Fix bug with `.includes("area")` which should read the opposite