### PR TITLE
Fix scroll bug with form expansion

### DIFF
--- a/src/assets/scss/_contact.scss
+++ b/src/assets/scss/_contact.scss
@@ -46,7 +46,7 @@
 
 .letter-send {
   position: relative;
-  background-color: rgba(112, 65, 207, 0.4);
+  background: linear-gradient(135deg, rgba(201, 174, 255, 0.6), rgba(176, 230, 252, 0.8));
   max-width: 100%;
   height: 100%;
   max-height: 28rem;

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -73,6 +73,12 @@ const SearchForm = ({
     if (showAdvanced) {
       // If user hits "minimise", reset the towns so they can select a department instead
       setValue("area", "");
+    } else {
+      // When the user hits "Advanced", if it is scrolled too far down, the form will jump to the bottom when expanded
+      const currentScrollPos = window.scrollY;
+      setTimeout(() => {
+        window.scrollTo(0, currentScrollPos);
+      }, 0);
     }
     setShowAdvanced(prev => !prev);
   }


### PR DESCRIPTION
- Fix issue where if user is too far scrolled down the page when they click "Advanced" to expand the search form, their form will expand but their device will be scrolled to the bottom of the form as it expands