### PR TITLE
Remove Netlify redirect logic

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,0 @@
-[[redirects]]
-  from = "/*"
-  to = "/"
-  status = 200


### PR DESCRIPTION
Remove Netlify redirect logic now that the site is no longer hosted on Netlify