### PR TITLE
Fix bug with sorting listings by increasing price

### DIFF
--- a/src/assets/scss/_sorting-dropdown.scss
+++ b/src/assets/scss/_sorting-dropdown.scss
@@ -9,7 +9,7 @@
   padding: 0.4rem 0;
   margin-left: auto;
   cursor: pointer;
-  z-index: 60;
+  z-index: 200;
   transition: 0.25s ease-in-out all;
 
   &:hover {
@@ -28,7 +28,7 @@
   transform: rotateX(-90deg);
   transition: transform 0.25s linear;
   padding: 0;
-  z-index: 60;
+  z-index: 200;
 }
 
 .sorting-dropdown-item {
@@ -38,7 +38,7 @@
   padding: 0.5rem 0.9rem;
   transition: 0.25s ease all;
   -webkit-transition: 0.25s ease all;
-  z-index: 60;
+  z-index: 200;
 
   &:hover {
     background-color: $color-primary;

--- a/src/components/SortingDropdown.jsx
+++ b/src/components/SortingDropdown.jsx
@@ -89,11 +89,10 @@ const SortingDropdown = ({ listingIDs, setListingIDs }) => {
     // If the user navigates to the saved listings page after sorting from the search results, sortingBy retains its value
     if (sortingBy) {
       let currentSort = sortingBy;
-      // const currentSort = sortingBy.indexOf("⇊") ? sortingBy.split(" ")
-      if (sortingBy.indexOf("⇊")) {
+      if (sortingBy.includes("⇊")) {
         currentSort = sortingBy.replace("⇊", "down");
-      } else if (sortingBy.indexOf("⇈")) {
-        currentSort = sortingBy.replace("⇊", "up");
+      } else if (sortingBy.includes("⇈")) {
+        currentSort = sortingBy.replace("⇈", "up");
       }
       handleSort(currentSort);
     }


### PR DESCRIPTION
- Fix a bug where if listings were sorted by price ascending, and the user refreshed the page, the listings would not be correctly sorted after the refresh
- Fix an intermittent issue where the sorting dropdown occasionally opens up behind the listing directly beneath it using `z-index`