### PR TITLE
Update click behavior between homepage and search

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,7 +1,18 @@
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 
+import { handlePageChange } from '../utilities';
+
+import { ListingsContext } from '..';
+
 const Home = () => {
+  const { setListingIDs } = useContext(ListingsContext);
+
+  // Reset the listingIDs whenever the user visits the homepage
+  useEffect(() => {
+    handlePageChange(setListingIDs);
+  }, []);
+
   return (
     <div className="hero-section">
       <div className="hero-section-img-container">
@@ -18,7 +29,6 @@ const Home = () => {
           </div>
         </h3>
         <p className="hero-intro-text">
-          {/* Say goodbye to endless scrolling and countless website tabs -  */}
           ImmoBee is here to <span className="hero-text-highlight">simplify your property search</span> and guide you towards finding the perfect place to call home. With an extensive database comprising more than 20 local agents, ImmoBee is your one-stop destination for hassle-free house hunting in Occitanie.
         </p>
         <Link className="btn btn-hero" to="/search/1">Search now</Link>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -4,7 +4,7 @@ import {
   useLocation
 } from 'react-router-dom';
 
-import { scrollTo } from '../utilities';
+import { handlePageChange, scrollTo } from '../utilities';
 
 import HamburgerMenu from './HamburgerMenu';
 
@@ -16,9 +16,7 @@ const Navbar = () => {
   const currentPage = location.pathname;
 
   const handleClick = scrollBehavior => {
-    setListingIDs([]);
-    localStorage.setItem("listingIDs", JSON.stringify([]));
-    scrollTo(0, scrollBehavior);
+    handlePageChange(setListingIDs, scrollBehavior);
   }
 
   return (

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -70,3 +70,9 @@ export const getSearchURL = (searchQuery, agentChoices) => {
 }
 
 export const scrollTo = (top = 0, behavior = "smooth") => window.scrollTo({top: top, behavior: behavior });
+
+export const handlePageChange = (setListingIDs, scrollBehavior) => {
+  setListingIDs([]);
+  localStorage.setItem("listingIDs", JSON.stringify([]));
+  if (scrollBehavior) scrollTo(0, scrollBehavior);
+}


### PR DESCRIPTION
- Ensure `listingIDs` is being reset whenever the user visits the homepage, even when that visit does not occur directly through the nav bar (i.e. they click an external link to visit the homepage)