### PR TITLE
Maintain scroll position for listings when using back btn

### DIFF
--- a/src/components/ListingsContainer.jsx
+++ b/src/components/ListingsContainer.jsx
@@ -129,7 +129,7 @@ const ListingsContainer = ({ listingIDs, loadingListings, loadingTimer, noListin
 
   useEffect(() => {
     // If the user hits the back button on the listing detail page, return them to their previous scroll position
-    if (searchResultsRef.current && refHasValue) {
+    if (searchResultsRef.current && refHasValue && listings.length) {
       if (window.history.state?.prevPage) {
         if (window.history.state.prevPage === "listing") {
           window.history.pushState({ prevPage: "" }, "");
@@ -147,7 +147,7 @@ const ListingsContainer = ({ listingIDs, loadingListings, loadingTimer, noListin
         }
       }
     }
-  }, [currentPage, isSavedListingsPage, loadingListings, refHasValue]);
+  }, [currentPage, isSavedListingsPage, listings, loadingListings, refHasValue]);
 
   if (noListingsFound) {
     return (


### PR DESCRIPTION
- Maintain the scroll position for the listings container when visiting an individual listing and then using the back button to go back to the search results