### PR TITLE
Recursively check node presence for image loading

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Link } from "react-router-dom";
 
 const Footer = () => {
+  const currentYear = new Date().getFullYear();
+
   return (
     <footer className="footer-container">
     <div className="footer-copyright">
       <span className="copyright-symbol">&copy;</span>
-      ImmoBee 2023
+      ImmoBee {currentYear}
     </div>
     <div>
       <img src="/bee-2.png" className="footer-bee" alt="" />

--- a/src/components/ImageControlSlider.jsx
+++ b/src/components/ImageControlSlider.jsx
@@ -7,15 +7,23 @@ import "slick-carousel/slick/slick-theme.css";
 const ImageControlSlider = ({ isDetailedListing, listingPhotos }) => {
   const [activeSlide, setActiveSlide] = useState(0);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 910);
-  const [arrowMargins, setArrowMargins] = useState(0);
+  const [arrowPosition, setArrowPosition] = useState(0);
 
   // Set initial padding when the controlBarRef is attached to a DOM node
   const listingImgRef = useCallback(node => {
+    // Recursively check img height until the image has loaded
+    const checkImgHeight = () => {
+      if (node.clientHeight) {
+        setArrowPosition(node.clientHeight / 2);
+      } else {
+        setTimeout(checkImgHeight, 50);
+      }
+    };
+
     if (node !== null) {
       const slideNumber = Number(node.dataset.slide);
       if (slideNumber === activeSlide) {
-        const imgHeight = node.clientHeight;
-        setArrowMargins(imgHeight / 2);
+        checkImgHeight();
       }
     }
   }, [activeSlide]);
@@ -36,7 +44,8 @@ const ImageControlSlider = ({ isDetailedListing, listingPhotos }) => {
         className={`${className} image-control-arrow ${prevArrow ? "image-control-arrow-prev" : ""}`}
         onClick={onClick}
         src="/arrow2.png"
-        style={{top: isDetailedListing ? arrowMargins + "px" : "102px"}}
+        // ensure the arrows for detailed listings don't display until they can be positioned correctly
+        style={{display: arrowPosition || !isDetailedListing ? "" : "none", top: isDetailedListing ? arrowPosition + "px" : "102px"}}
       />
     );
   }


### PR DESCRIPTION
- On the listing detail page, the arrow `top` position should be set once the image has loaded to ensure that, regardless of image height, the arrows are vertically centered. The images vary drastically in size due to the different ways agencies handle their images, so loading times are unpredictable. Recursively checking if the image has loaded and the DOM node has a value every 50 ms is a balanced approach as most images will load extremely quickly, and this creates a buffer for those images that take longer.
- Update the footer with the correct year for copyright purposes