### PR TITLE
Ensure save icon is visible over swipe library

### DIFF
--- a/src/assets/scss/pages/_listings.scss
+++ b/src/assets/scss/pages/_listings.scss
@@ -499,13 +499,11 @@
     top: 0;
     left: 0;
   }
-
-  * {
-    z-index: 2;
-  }
 }
 
 .listing-detail-save-container {
+  position: relative;
+  
   .listing-interactive-icon-container {
     top: 1.5rem;
     right: 2rem;


### PR DESCRIPTION
- Adding the swipe library has updated the position of the save icon on the listing detail page, so this PR resets it to ensure it is always visible