### PR TITLE
Allow users to visit listing detail for removed listings

### DIFF
--- a/src/assets/scss/pages/_listings.scss
+++ b/src/assets/scss/pages/_listings.scss
@@ -186,7 +186,6 @@
 .listing-container-hidden {
   cursor: default;
   pointer-events: none;
-  background-color: redyo;
 
   &:hover {
     box-shadow:
@@ -253,24 +252,33 @@
   z-index: 10;
   top: 1rem;
   right: 1rem;
-
   cursor: pointer;
   transition: all ease 200ms;
   -webkit-transition: all ease 200ms;
 
+  i {
+    transition: all ease 200ms;
+    -webkit-transition: all ease 200ms;
+  }
+
   &:hover {
     background-color: #292323e4;
 
-    .heart-icon {
-      color: #e80e32;
+    i {
       transition: all ease 200ms;
       -webkit-transition: all ease 200ms;
     }
 
+    .heart-icon {
+      color: #e80e32;
+    }
+
     .eye-icon {
       color: $white;
-      transition: all ease 200ms;
-      -webkit-transition: all ease 200ms;
+    }
+
+    .x-icon {
+      color: $color-secondary-highlight;
     }
   }
 }
@@ -289,8 +297,6 @@
   font-weight: 400;
   color: #fc5d78;
   z-index: 10;
-  transition: all ease 200ms;
-  -webkit-transition: all ease 200ms;
 
   &.saved {
     font-weight: 900;
@@ -324,8 +330,6 @@
   font-size: 1.4rem;
   color: rgb(205, 197, 197);
   z-index: 10;
-  transition: all ease 200ms;
-  -webkit-transition: all ease 200ms;
 }
 
 .no-images-text {
@@ -528,6 +532,16 @@
     top: 0;
     left: 0;
   }
+}
+
+.listing-detail-removed-note {
+  position: relative;
+  font-family: "ChelseaMarket";
+  color: $color-text;
+  text-align: center;
+  white-space: pre-wrap;
+  z-index: 2;
+  padding: 1rem 2rem;
 }
 
 .listing-detail-save-container {

--- a/src/components/listings/Listing.jsx
+++ b/src/components/listings/Listing.jsx
@@ -23,9 +23,17 @@ const Listing = ({ listing }) => {
 
   // ensure listing is only selected if other buttons on the listing are not clicked
   const handleSelectListing = (e) => {
-    const otherTargets = ["slick-arrow", "listing-image-circle", "listing-image-current", "listing-interactive-icon-container", "heart-icon", "eye-icon"];
+    const otherTargets = ["slick-arrow", "listing-image-circle", "listing-image-current", "listing-interactive-icon-container", "heart-icon", "eye-icon", "btn-removed-listing", "x-icon"];
     const classNames = e.target.classList;
     
+    const listingContainer = e.target.closest(".listing-container");
+    // If a listing has been removed from the DB, only allow users to click on it if it has the "show-removed-listing-container" class
+    if (listingContainer.classList.contains("listing-container-hidden") && 
+       !listingContainer.classList.contains("show-removed-listing-container")) {
+        e.preventDefault();
+        return;
+    }
+
     for (let className of classNames) {
       if (otherTargets.indexOf(className) !== -1) {
         // e.button === 0 is a left click

--- a/src/components/listings/ListingDetail.jsx
+++ b/src/components/listings/ListingDetail.jsx
@@ -48,6 +48,12 @@ const ListingDetail = () => {
 
   return (
     <div className="listing-detail-page-container">
+      {listing.removedFromDB &&
+        <div className="listing-detail-removed-note">
+          NOTE: This listing has been removed and as a result, has been archived in your browser.
+          {"\n"}You can continue to view this page but cannot send a link to others or view it on another device.
+        </div>
+      }
       <div className="listing-detail-save-container">
         <SaveListing isSaved={isSaved} listing={listing} setIsSaved={setIsSaved} />
         <FullScreenIcon listingPhotos={listing.photos_hosted} />

--- a/src/components/listings/ListingWrapper.jsx
+++ b/src/components/listings/ListingWrapper.jsx
@@ -19,9 +19,7 @@ const ListingWrapper = ({ children, handleMiddleClick, handleSelectListing, isHi
     setDisplayListing(false);
   }
 
-  if (!displayListing) {
-    return null;
-  }
+  if (!displayListing) return null;
 
   if (isHidden) {
     return (
@@ -38,9 +36,18 @@ const ListingWrapper = ({ children, handleMiddleClick, handleSelectListing, isHi
     )
   }
 
-  if (listing.removedFromDB) {
-    return (
-      <div className={`listing-container listing-container-hidden ${viewRemovedListing ? "show-removed-listing-container" : ""}`}>
+  return (
+    <a
+      className={`listing-container
+        ${listing.removedFromDB ? "listing-container-hidden" : ""}
+        ${viewRemovedListing ? "show-removed-listing-container" : ""}
+      `}
+      href={`/listings/${listing.listingID}`}
+      onContextMenu={handleSelectListing}
+      onClick={handleSelectListing}
+      onMouseDown={handleMiddleClick}
+    >
+      {listing.removedFromDB && 
         <div className="listing-hidden-info-container">
           This listing has been removed by the agent. You can view the original listing, or remove it from your saved listings.
           <button className="btn btn-undo btn-removed-listing" onClick={() => setViewRemovedListing(true)}>
@@ -52,19 +59,7 @@ const ListingWrapper = ({ children, handleMiddleClick, handleSelectListing, isHi
             Remove listing
           </button>
         </div>
-        {children}
-      </div>
-    )
-  } 
-
-  return (
-    <a
-      className="listing-container"
-      href={`/listings/${listing.listingID}`}
-      onContextMenu={handleSelectListing}
-      onClick={handleSelectListing}
-      onMouseDown={handleMiddleClick}
-    >
+      }
       {children}
     </a>
   )


### PR DESCRIPTION
- Allow users to continue to view the detailed listing page, even for listings that have been removed from the database
- The data for these listings is saved in the user's local storage and will be removed when they choose to remove a saved listing
