### PR TITLE
Put removed listing notice into closeable banner

### DIFF
--- a/src/assets/scss/base/_media.scss
+++ b/src/assets/scss/base/_media.scss
@@ -39,6 +39,12 @@
   }
 }
 
+@media screen and (max-width: 990px) {
+  .listing-detail-banner-content {
+    white-space: unset;
+  }
+}
+
 @media screen and (max-width: 960px) {
   .hero-subtitle {
     font-size: 2.3rem;
@@ -353,6 +359,10 @@
   .unknown-listings-subtitle {
     margin: 1.75rem 0 0.5rem 0;
   }
+
+  .listing-detail-banner-content {
+    padding: 0.75rem;
+  }
 }
 
 @media screen and (max-width: 670px) {
@@ -561,6 +571,12 @@
 
   .search-radius-slider {
     width: 20rem;
+  }
+
+  // listing detail  
+  .listing-detail-banner-content {
+    font-size: 0.9rem;
+    padding: 0.25rem;
   }
 
   // contact page

--- a/src/assets/scss/components/_buttons.scss
+++ b/src/assets/scss/components/_buttons.scss
@@ -192,3 +192,19 @@
     outline: none;
   }
 }
+
+.btn-x {
+  height: fit-content;
+  background-color: transparent;
+  border: none;
+  padding: 0.5rem;
+  margin-top: -0.5rem;
+  transition: all ease 200ms;
+  -webkit-transition: all ease 200ms;
+
+  &:hover {
+    color: $color-tertiary;
+    transition: all ease 200ms;
+    -webkit-transition: all ease 200ms;
+  }
+}

--- a/src/assets/scss/pages/_listings.scss
+++ b/src/assets/scss/pages/_listings.scss
@@ -534,14 +534,39 @@
   }
 }
 
-.listing-detail-removed-note {
+.listing-detail-banner-container {
+  display: flex;
+  justify-content: center;
+  padding: 0 1rem;
+  z-index: 2;
+
+  * {
+    z-index: inherit;
+  }
+}
+
+.listing-detail-banner {
+  display: flex;
+  justify-content: center;
+  width: fit-content;
+  background-color: rgba($color-tertiary, 0.12);
+  border: 2px solid rgba($color-secondary-highlight, 0.3);
+  border-radius: 10px;
+  padding: 0.4rem;
+  margin: 1rem auto 0 auto;
+}
+
+.banner-x-icon {
+  font-size: 2rem;
+}
+
+.listing-detail-banner-content {
   position: relative;
   font-family: "ChelseaMarket";
   color: $color-text;
   text-align: center;
   white-space: pre-wrap;
-  z-index: 2;
-  padding: 1rem 2rem;
+  padding: 0.75rem 2rem;
 }
 
 .listing-detail-save-container {

--- a/src/components/listings/ListingDetail.jsx
+++ b/src/components/listings/ListingDetail.jsx
@@ -16,6 +16,7 @@ const ListingDetail = () => {
   const [isSaved, setIsSaved] = useState(
     JSON.parse(localStorage.getItem("savedListings"))?.some(savedListing => savedListing?.link_url === listing?.link_url) || null
   );
+  const [showRemovedListingBanner, setShowRemovedListingBanner] = useState(listing?.removedFromDB || false);
 
   // Delete local storage item once accessed
   useEffect(() => {
@@ -48,10 +49,17 @@ const ListingDetail = () => {
 
   return (
     <div className="listing-detail-page-container">
-      {listing.removedFromDB &&
-        <div className="listing-detail-removed-note">
-          NOTE: This listing has been removed and as a result, has been archived in your browser.
-          {"\n"}You can continue to view this page but cannot send a link to others or view it on another device.
+      {showRemovedListingBanner && 
+      <div className="listing-detail-banner-container">
+          <div className="listing-detail-banner">
+            <div className="listing-detail-banner-content">
+              NOTE: This listing has been removed and as a result, has been archived in your browser.
+              {"\n"}You can continue to view this page but cannot send a link to others or view it on another device.
+            </div>
+            <button className="btn-x" onClick={() => setShowRemovedListingBanner(false)}>
+              <i className="fa-solid fa-xmark banner-x-icon" />
+            </button>
+          </div>
         </div>
       }
       <div className="listing-detail-save-container">


### PR DESCRIPTION
- Put the "This listing has been removed" notice into a banner at the top of the listing detail page, so users can close it and still see the listing images fill the screen as before without having to scroll